### PR TITLE
fix: Initialize submodules and build Web UI in docker-release workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -71,6 +73,16 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Build Web UI
+        run: |
+          npm ci --prefix src/main/webui
+          npm run build --prefix src/main/webui
 
       - name: Build application
         run: ./mvnw package -DskipTests


### PR DESCRIPTION
## Problem
The docker-release workflow was failing because `src/main/webui` is a git submodule that wasn't being initialized during the GitHub Actions checkout. This caused the Quarkus Quinoa extension to fail with: 'No package.json found in Web UI directory: src/main/webui'.

## Solution
- Added `submodules: true` to the checkout step to initialize the `src/main/webui` submodule
- Added Node.js setup step (v18) before the Maven build
- Added Web UI build step to install dependencies and build the frontend before Quinoa processes it

## Changes
- Updated `.github/workflows/docker-release.yml` to:
  1. Initialize submodules during checkout
  2. Set up Node.js environment
  3. Build the Web UI before running Maven package

This ensures the frontend code is present and built before the Quarkus/Quinoa build step runs.

Fixes the build failure from run ref 268ce58f7d6d691e9ec4acdafbd931b44747d1ab