### PR TITLE
Refactor: Remove redundant manual web UI build from Docker workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -78,14 +78,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-
-      - name: Build Web UI
-        run: |
-          npm ci --prefix src/main/webui
-          npm run build --prefix src/main/webui
+        # Node.js is required for Quinoa to build the frontend during Maven package
 
       - name: Build application
         run: ./mvnw package -DskipTests
+        # Quinoa automatically builds the frontend (npm install + npm run build) during this step
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Problem
The Docker release workflow was manually building the web UI before Maven package, but Quinoa already handles this automatically during the Maven build process.

## Solution
- ✅ Removed redundant `Build Web UI` step (npm ci + npm run build)
- ✅ Added comments explaining that Quinoa handles the frontend build
- ✅ Kept Node.js setup (required for Quinoa to work)

## Benefits
- **Simpler workflow**: One less step to maintain
- **No duplication**: Frontend is built once by Quinoa, not twice
- **Consistent**: Same build process as local development
- **Verified**: Confirmed during local testing that Quinoa builds automatically

## How It Works
When `./mvnw package` runs, Quinoa will:
1. Detect the frontend needs building
2. Run `npm install` automatically (if needed)
3. Run `npm run build` automatically
4. Package the built files into the Quarkus application

## Testing
- ✅ Tested locally: Quinoa successfully builds frontend during Maven package
- ✅ Docker image builds correctly with Quinoa-built frontend
- ✅ Frontend is properly served in the Docker container