### PR TITLE
Fix: Select All now respects header filters in ExpenseTable

### DIFF
--- a/src/main/webui/src/components/visualization/ExpenseTable.tsx
+++ b/src/main/webui/src/components/visualization/ExpenseTable.tsx
@@ -249,7 +249,8 @@ export function ExpenseTable() {
                     columnDefs={columnDefs}
                     defaultColDef={defaultColDef}
                     animateRows={true}
-                    rowSelection={{ mode: 'multiRow' }}
+                    // Ensure header "Select All" respects current filtering
+                    rowSelection={{ mode: 'multiRow', selectAll: 'filtered' }}
                     pagination={true}
                     paginationPageSize={20}
                     suppressMenuHide={true}


### PR DESCRIPTION
- Configure AG Grid rowSelection with selectAll: 'filtered' so header Select All checkbox only selects rows matching current filter criteria
- Add E2E test shouldSelectAllOnlyFilteredRowsInExpenseTable to verify the fix: filters table to 1 row, clicks Select All, asserts Delete Selected count matches filtered total (not full dataset)

Fixes issue where Select All would select all records regardless of active column filters, potentially causing unintended bulk deletions.