### PR TITLE
Fix: Exclude income from merchant spending analytics

### DIFF
--- a/src/main/webui/src/hooks/__tests__/useMerchantAnalytics.test.tsx
+++ b/src/main/webui/src/hooks/__tests__/useMerchantAnalytics.test.tsx
@@ -17,7 +17,8 @@ const buildTransactions = () => {
         transactionId: index + 1,
         transactionDate: `2025-01-${String(index + 1).padStart(2, "0")}`,
         description: `Merchant ${index + 1}`,
-        amount: -(index + 1) * 10,
+        // POSITIVE amounts are expenses (spending)
+        amount: (index + 1) * 10,
         category: index % 2 === 0 ? "Dining" : "Travel",
         accountName: "Test Account",
         bankName: "Test Bank",
@@ -29,7 +30,7 @@ const duplicateTransactions = [
         transactionId: 100,
         transactionDate: "2025-02-01",
         description: "Merchant 1",
-        amount: -200,
+        amount: 200,
         category: "Dining",
         accountName: "Test Account",
         bankName: "Test Bank",
@@ -38,8 +39,18 @@ const duplicateTransactions = [
         transactionId: 101,
         transactionDate: "2025-02-05",
         description: "Merchant 1",
-        amount: -50,
+        amount: 50,
         category: "Dining",
+        accountName: "Test Account",
+        bankName: "Test Bank",
+    },
+    // Negative amounts are income/payments/transfers and should NOT count as spending.
+    {
+        transactionId: 102,
+        transactionDate: "2025-02-10",
+        description: "Merchant 1",
+        amount: -999,
+        category: "Income",
         accountName: "Test Account",
         bankName: "Test Bank",
     },
@@ -100,7 +111,8 @@ describe("useMerchantAnalytics", () => {
         const hook = renderHook();
         const topMerchant = hook.current!.merchantData[0];
 
-        // Merchant 1 has the highest total (10 + 200 + 50 = 260) due to duplicate transactions
+        // Merchant 1 has the highest total (10 + 200 + 50 = 260).
+        // The negative income transaction is ignored.
         expect(topMerchant.merchant).toBe("Merchant 1");
         expect(topMerchant.totalSpent).toBe(260);
         expect(topMerchant.transactionCount).toBe(3);
@@ -192,7 +204,7 @@ describe("useMerchantAnalytics", () => {
 
     it("reports lack of transactions when the dataset is empty", () => {
         transactions = [];
-        dateRangeSpy.mockReturnValue({ data: [] } as ReturnType<typeof dateRangeQuery.useDateRangeQuery>);
+        dateRangeSpy.mockReturnValue({ data: [] } as unknown as ReturnType<typeof dateRangeQuery.useDateRangeQuery>);
         storeSpy.mockReturnValue({
             transactions,
             setTransactions: vi.fn(),

--- a/src/main/webui/src/hooks/useMerchantAnalytics.ts
+++ b/src/main/webui/src/hooks/useMerchantAnalytics.ts
@@ -55,8 +55,10 @@ export const useMerchantAnalytics = () => {
             // Skip excluded merchants
             if (excludedMerchants.includes(merchant)) return;
 
-            // Skip transactions with no amount
-            if (transaction.amount === 0) return;
+            // Merchant spending analytics should only include expenses.
+            // Convention across the app: POSITIVE amounts are expenses (spending),
+            // NEGATIVE amounts are income/payments/transfers/refunds.
+            if (transaction.amount <= 0) return;
 
             // Initialize merchant data if not exists
             if (!merchantMap.has(merchant)) {
@@ -73,12 +75,12 @@ export const useMerchantAnalytics = () => {
             const data = merchantMap.get(merchant)!;
 
             // Increment merchant stats
-            data.totalSpent += Math.abs(transaction.amount);
+            data.totalSpent += transaction.amount;
             data.transactionCount += 1;
 
             // Track spending by category
             const category = transaction.category || 'Uncategorized';
-            data.categories[category] = (data.categories[category] || 0) + Math.abs(transaction.amount);
+            data.categories[category] = (data.categories[category] || 0) + transaction.amount;
 
             // Update last transaction date if newer
             if (new Date(transaction.transactionDate) > new Date(data.lastTransaction)) {


### PR DESCRIPTION
## Summary
- Merchant spending analytics now only aggregates expense transactions (positive amounts).
- Prevents income/payments (negative amounts) from being counted as spending.
- Updates/adds tests to cover the behavior.

## Test plan
- [x] `npm test -t useMerchantAnalytics` (passes)
- [x] Open `/visualization` → Merchant Spending Analysis and confirm income rows are not included